### PR TITLE
Fix dependencies to allow build to work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,16 +94,18 @@ dependencies {
 //    compile 'CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.19.548'
 //    compile "com.blamejared:MTLib:3.0.4.8"
     compile "com.azanor.baubles:Baubles:1.12-1.5.2"
-    compile "thaumcraft:Thaumcraft:1.12.2:6.1.BETA26"
+    compile fg.deobf("curse.maven:thaumcraft-223628:2629023")
     compile 'slimeknights.mantle:Mantle:1.12-1.3.3.49'
     compile 'slimeknights:TConstruct:1.12.2-2.13.0.184'
 //    compile 'constructs-armory:conarm:1.12.2:1.2.5.4'
-    compile 'bewitchment:bewitchment:1.12.2:0.0.21.4'
+    compile 'curse.maven:bewitchment-285439:3256343'
+    runtimeOnly 'curse.maven:patchouli-306770:3087124'
 //    compile fg.deobf("curse.maven:thaumicbases:3056921")
 //    compile "curse.maven:dummycore:2611426"
     compile "tk.zeitheron.HammerLib:HammerLib-1.12.2:2.0.6.19:deobf"
     compile "tk.zeitheron.ThaumicAdditions:ThaumicAdditions-1.12.2:12.4.3:deobf"
-    compile "curse.maven:soot:3056967"
+    compile "curse.maven:soot-281528:3056967"
+    runtimeOnly "curse.maven:embers-rekindled-300777:3225431"
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..


### PR DESCRIPTION
Related: #11 

This PR fixes the dependencies to get to a state where compiling the mod is possible. Namely:

- The CurseMaven entry for Soot was fixed
- Bewitchment was switched to use the CurseMaven, as the old entry failed
- Thaumcraft is now deobfuscated
- Patchouli and Embers Rekindled were added to the runtime as they are required by Bewitchment and Soot, respectively

Note that `runClient` or otherwise running in dev does not seem to work - Eclipse is totally messed up, and on the command line the game loads until eventually Thaumic Additions crashes for some reason. Unfortunately, I am not well-versed enough with ForgeGradle 3 and later to understand why these things occur. Until this is resolved, it is at least now possible to build the mod and copy to a Forge instance for testing.